### PR TITLE
feat(update-user): update user fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/joho/godotenv v1.3.0
 	github.com/mitchellh/mapstructure v1.4.1
 	go.mongodb.org/mongo-driver v1.7.1
+	gopkg.in/go-playground/validator.v9 v9.31.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/googollee/go-socket.io v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/joho/godotenv v1.3.0
-	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/mitchellh/mapstructure v1.4.1
 	go.mongodb.org/mongo-driver v1.7.1
 )

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/go-playground/validator.v9 v9.31.0 h1:bmXmP2RSNtFES+bn4uYuHT7iJFJv7Vj+an+ZQdDaD1M=
+gopkg.in/go-playground/validator.v9 v9.31.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -38,7 +38,9 @@ func Router(Server *socketio.Server) *mux.Router {
 	//r.HandleFunc("/marketplace/plugins/{id}", marketplace.GetOneApprovedPlugin).Methods("GET")
 	//r.HandleFunc("/marketplace/install", marketplace.InstallPluginToOrg).Methods("POST")
 	r.HandleFunc("/users", user.Create).Methods("POST")
-	
+	r.HandleFunc("/users/{id}", user.FindUserByID).Methods("GET")
+	r.HandleFunc("/users/{id}", user.UpdateUser).Methods("PATCH")
+
 	http.Handle("/", r)
 
 	return r

--- a/user/models.go
+++ b/user/models.go
@@ -85,3 +85,11 @@ type User struct {
 	EmailVerification UserEmailVerification   `bson:"email_verification"`
 	PasswordResets    []*UserPasswordReset    `bson:"password_resets"`
 }
+
+// Struct that user can update directly
+type UserUpdate struct {
+	FirstName string `bson:"first_name" validate:"required,min=2,max=100" json:"first_name"`
+	LastName  string `bson:"last_name" validate:"required,min=2,max=100" json:"last_name"`
+	Phone     string `bson:"phone" validate:"required" json:"phone"`
+	Company   string `bson:"company" json:"company"`
+}

--- a/user/user.go
+++ b/user/user.go
@@ -2,12 +2,15 @@ package user
 
 import (
 	"errors"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"zuri.chat/zccore/utils"
+	"github.com/gorilla/mux"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // An end point to create new users
@@ -16,7 +19,7 @@ func Create(response http.ResponseWriter, request *http.Request) {
 	user_collection := "users"
 
 	var user User
-	
+
 	err := utils.ParseJsonFromRequest(request, &user)
 	if err != nil {
 		utils.GetError(err, http.StatusUnprocessableEntity, response)
@@ -27,7 +30,7 @@ func Create(response http.ResponseWriter, request *http.Request) {
 		utils.GetError(errors.New("email address is not valid"), http.StatusBadRequest, response)
 		return
 	}
-	
+
 	// confirm if user_email exists
 	result, _ := utils.GetMongoDbDoc(user_collection, bson.M{"email": user.Email})
 	if result != nil {
@@ -35,13 +38,13 @@ func Create(response http.ResponseWriter, request *http.Request) {
 		utils.GetError(errors.New("operation failed"), http.StatusBadRequest, response)
 		return
 	}
-		
+
 	user.CreatedAt = time.Now()
 
 	detail, _ := utils.StructToMap(user)
 
 	res, err := utils.CreateMongoDbDoc(user_collection, detail)
-	
+
 	if err != nil {
 		utils.GetError(err, http.StatusInternalServerError, response)
 		return
@@ -51,17 +54,58 @@ func Create(response http.ResponseWriter, request *http.Request) {
 }
 
 // helper functions perform CRUD operations on user
-// func FindUserByID(response http.ResponseWriter, request *http.Request) {
-// 	user := &User{}
-// 	collectionName := "users"
-// 	objID, _ := primitive.ObjectIDFromHex(id)
-// 	collection := utils.GetCollection(collectionName)
-// 	res := collection.FindOne(ctx, bson.M{"_id": objID})
-// 	if err := res.Decode(user); err != nil {
-// 		return nil, err
-// 	}
-// 	return user, nil
-// }
+func FindUserByID(response http.ResponseWriter, request *http.Request) {
+	// Find a user by user ID
+	response.Header().Set("content-type", "application/json")
+
+	collectionName := "users"
+	userID := mux.Vars(request)["id"]
+	objID, _ := primitive.ObjectIDFromHex(userID)
+
+	res, err := utils.GetMongoDbDoc(collectionName, bson.M{"_id": objID})
+	if err != nil {
+		utils.GetError(err, http.StatusInternalServerError, response)
+		return
+	}
+	utils.GetSuccess("User retrieved successfully", res, response)
+
+}
+
+func UpdateUser(response http.ResponseWriter, request *http.Request) {
+	// Update a user of a given ID
+	response.Header().Set("content-type", "application/json")
+
+	collectionName := "users"
+	userID := mux.Vars(request)["id"]
+	objID, _ := primitive.ObjectIDFromHex(userID)
+
+	res, err := utils.GetMongoDbDoc(collectionName, bson.M{"_id": objID})
+	if err != nil {
+		utils.GetError(err, http.StatusInternalServerError, response)
+		return
+	}
+
+	if res != nil {
+		// 2. Get user fields to be updated from request body
+		var body map[string]interface{}
+		err := json.NewDecoder(request.Body).Decode(&body)
+		if err != nil {
+			utils.GetError(err, http.StatusBadRequest, response)
+			return
+		}
+
+		// 2'. Do not allow email update
+
+		// 3. Update user
+		updateRes, err := utils.UpdateOneMongoDbDoc(collectionName, userID, body)
+		if err != nil {
+			utils.GetError(err, http.StatusInternalServerError, response)
+			return
+		}
+		utils.GetSuccess("User update successful", updateRes, response)
+	}
+
+}
 
 // func FindUsers(ctx context.Context, filter M) ([]*User, error) {
 // 	users := []*User{}

--- a/user/user.go
+++ b/user/user.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/go-playground/validator/v10"
 	"github.com/gorilla/mux"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -103,6 +104,16 @@ func UpdateUser(response http.ResponseWriter, request *http.Request) {
 			utils.GetError(err, http.StatusBadRequest, response)
 			return
 		}
+		fmt.Printf("request body %v", body)
+
+		// 3. Validate request body
+		structValidator := validator.New()
+		err = structValidator.Struct(body)
+
+		if err != nil {
+			utils.GetError(err, http.StatusBadRequest, response)
+			return
+		}
 
 		// Convert body struct to interface
 		var userInterface map[string]interface{}
@@ -112,8 +123,8 @@ func UpdateUser(response http.ResponseWriter, request *http.Request) {
 		}
 		json.Unmarshal(bytes, &userInterface)
 
-		// 3. Update user
-		updateRes, err := utils.UpdateOneMongoDbDoc(collectionName, userID, userInterface)
+		// 4. Update user
+		updateRes, err := utils.UpdateOneMongoDbDoc(collectionName, objID.String(), userInterface)
 		if err != nil {
 			utils.GetError(err, http.StatusInternalServerError, response)
 			return


### PR DESCRIPTION
### What does this PR do?
- Adds functionality to get an existing user by user ID
- Adds functionality to update user's fields
### Tasks completed
- Find user by ID: `GET '/users/{id}'` where `id` corresponds to a MongoDB document id (`_id`)
- Update user of a given ID: `PATCH '/users/{id}'`
### How should this be tested?
With postman, take the following steps:
- Start the server: `go run main.go`
- Create a user: `POST '/users'`. Provide a body with these JSON fields `{"FirstName": "Jane", "LastName": "Doe", "Email": "janedoe@email.com", "password": "complexpassword"}`
- Read created user: `GET '/users/{id}'` where `id` is contained in the response from creating a user. 
- Update some user field: `PATCH '/users/{id}'`. Provide a body `{
    "FirstName": "Millicent",
    "LastName": "Bystander",
    "Phone": "987654321",
    "Company": "Zuri Chat",
    "Organizations": ["Zuri Main", "Zuri Core"]
}` and then read the user to check the updated fields
### Pending Tasks
- User input validation
### Issue Reference
- #37 
- #99 

### Status: Work-In-Progress
- A rudimentary implementation of user field updates without validation
- Endpoints are not authenticated. Awaiting authentication from: 
     - #155 
     - #113 
     - #118