### PR TITLE
Added an Endpoint for user to delete Profile 

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,8 +37,11 @@ func Router(Server *socketio.Server) *mux.Router {
 	//r.HandleFunc("/marketplace/plugins", marketplace.GetAllApprovedPlugins).Methods("GET")
 	//r.HandleFunc("/marketplace/plugins/{id}", marketplace.GetOneApprovedPlugin).Methods("GET")
 	//r.HandleFunc("/marketplace/install", marketplace.InstallPluginToOrg).Methods("POST")
+
+	// Users Endpoint
 	r.HandleFunc("/users", user.Create).Methods("POST")
-	
+	r.HandleFunc("/users/{user_id}", user.Delete).Methods("DELETE")
+
 	http.Handle("/", r)
 
 	return r

--- a/user/user.go
+++ b/user/user.go
@@ -91,7 +91,7 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 
 	collectionName := "users"
 	params := mux.Vars(r)
-	id := param["_id"]
+	id := params["user_id"]
 
 	err := db.DeleteOneMongoDoc(collectionName, id)
 

--- a/user/user.go
+++ b/user/user.go
@@ -94,7 +94,7 @@ func Delete(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
 	id := params["user_id"]
 
-	err := db.DeleteOneMongoDoc(collectionName, id)
+	err := utils.DeleteOneMongoDoc(collectionName, id)
 
 	if err != nil {
 		utils.GetError(err, http.StatusInternalServerError, w)

--- a/user/user.go
+++ b/user/user.go
@@ -16,7 +16,7 @@ func Create(response http.ResponseWriter, request *http.Request) {
 	user_collection := "users"
 
 	var user User
-	
+
 	err := utils.ParseJsonFromRequest(request, &user)
 	if err != nil {
 		utils.GetError(err, http.StatusUnprocessableEntity, response)
@@ -27,7 +27,7 @@ func Create(response http.ResponseWriter, request *http.Request) {
 		utils.GetError(errors.New("email address is not valid"), http.StatusBadRequest, response)
 		return
 	}
-	
+
 	// confirm if user_email exists
 	result, _ := utils.GetMongoDbDoc(user_collection, bson.M{"email": user.Email})
 	if result != nil {
@@ -35,13 +35,13 @@ func Create(response http.ResponseWriter, request *http.Request) {
 		utils.GetError(errors.New("operation failed"), http.StatusBadRequest, response)
 		return
 	}
-		
+
 	user.CreatedAt = time.Now()
 
 	detail, _ := utils.StructToMap(user)
 
 	res, err := utils.CreateMongoDbDoc(user_collection, detail)
-	
+
 	if err != nil {
 		utils.GetError(err, http.StatusInternalServerError, response)
 		return
@@ -85,3 +85,18 @@ func Create(response http.ResponseWriter, request *http.Request) {
 // func CreateUserProfile(ctx context.Context, uw *UserWorkspace) error {
 // 	return nil
 // }
+
+// An Endpoint to delete user Profile
+func Delete(w http.ResponseWriter, r *http.Request) {
+
+	collectionName := "users"
+	params := mux.Vars(r)
+	id := param["_id"]
+
+	err := db.DeleteOneMongoDoc(collectionName, id)
+
+	if err != nil {
+		utils.GetError(err, http.StatusInternalServerError, w)
+		return
+	}
+}

--- a/user/user.go
+++ b/user/user.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/gorilla/mux"
 	"go.mongodb.org/mongo-driver/bson"
 	"zuri.chat/zccore/utils"
 )


### PR DESCRIPTION
## What does this PR do?

- Adds functionality to get an existing user by user ID and delete their profile


## Tasks completed

- Find user by ID and delete it: DELETE'/users/{id}' where id corresponds to a MongoDB document id (_id)

## Issue Reference
Fixes #31