### PR TITLE
Update User fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/go-playground/validator/v10 v10.9.0
-	github.com/gofrs/uuid v4.0.0+incompatible // indirect
+	github.com/gofrs/uuid v4.0.0+incompatible
 	github.com/googollee/go-socket.io v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/joho/godotenv v1.3.0

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func Router(Server *socketio.Server) *mux.Router {
 	// Users
 	r.HandleFunc("/users", user.Create).Methods("POST")
 	// r.HandleFunc("/users/{id}", user.FindUserByID).Methods("GET")
-	r.HandleFunc("/users/{id}", user.UpdateUser).Methods("PATCH")
+	r.HandleFunc("/users/{user_id}", user.UpdateUser).Methods("PATCH")
 	r.HandleFunc("/users/{user_id}", user.Retrive).Methods("GET")
 	r.HandleFunc("/users/{user_id}", user.DeleteUser).Methods("DELETE")
 	r.HandleFunc("/users/search/{query}", user.SearchOtherUsers).Methods("GET")

--- a/user/user.go
+++ b/user/user.go
@@ -64,7 +64,6 @@ func Create(response http.ResponseWriter, request *http.Request) {
 	utils.GetSuccess("user created", res, response)
 }
 
-
 // an endpoint to search other users
 func SearchOtherUsers(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
@@ -111,15 +110,17 @@ func FindUserByID(response http.ResponseWriter, request *http.Request) {
 	response.Header().Set("content-type", "application/json")
 
 	collectionName := "users"
-	userID := mux.Vars(request)["id"]
-	objID, err := primitive.ObjectIDFromHex(userID)
+
+	params := mux.Vars(request)
+	userId := params["user_id"]
+	objId, err := primitive.ObjectIDFromHex(userId)
 
 	if err != nil {
 		utils.GetError(errors.New("invalid id"), http.StatusBadRequest, response)
 		return
 	}
 
-	res, err := utils.GetMongoDbDoc(collectionName, bson.M{"_id": objID})
+	res, err := utils.GetMongoDbDoc(collectionName, bson.M{"_id": objId})
 	if err != nil {
 		utils.GetError(errors.New("user not found"), http.StatusInternalServerError, response)
 		return
@@ -133,7 +134,7 @@ func FindUserByID(response http.ResponseWriter, request *http.Request) {
 func UpdateUser(response http.ResponseWriter, request *http.Request) {
 	response.Header().Set("content-type", "application/json")
 	// Validate the user ID
-	userID := mux.Vars(request)["id"]
+	userID := mux.Vars(request)["user_id"]
 	objID, err := primitive.ObjectIDFromHex(userID)
 	if err != nil {
 		utils.GetError(errors.New("invalid user ID"), http.StatusBadRequest, response)

--- a/user/user.go
+++ b/user/user.go
@@ -129,6 +129,7 @@ func UpdateUser(response http.ResponseWriter, request *http.Request) {
 			}
 		}
 		if len(updateFields) == 0 {
+			utils.GetError(errors.New("empty/invalid user input data"), http.StatusBadRequest, response)
 			return
 		} else {
 			updateRes, err := utils.UpdateOneMongoDbDoc(collectionName, userID, updateFields)

--- a/user/user.go
+++ b/user/user.go
@@ -87,10 +87,10 @@ func FindUserByID(response http.ResponseWriter, request *http.Request) {
 
 	res, err := utils.GetMongoDbDoc(collectionName, bson.M{"_id": objID})
 	if err != nil {
-		utils.GetError(err, http.StatusInternalServerError, response)
+		utils.GetError(errors.New("user not found"), http.StatusInternalServerError, response)
 		return
 	}
-	utils.GetSuccess("User retrieved successfully", res, response)
+	utils.GetSuccess("user retrieved successfully", res, response)
 
 }
 


### PR DESCRIPTION
### What does this PR do?
- Allow existing users to update certain/given fields
- The fields are currently limited to the following: `first_name`, `last_name`, `phone`, and `company`

### Task completed 
- Update user: `PATCH '/users/{user_id}'`

### How should this be tested?
With postman, perform the following tasks:
1. Create a user: `POST '/users'`with post body: 
`{
	"first_name": "Millicent",
	"last_name": "Bystander",
	"email": "mb@org.com",
	"password": "password",
	"phone": "9876543210",
	"company": "Flushed Away Inc"
}`
2. Read created user: `GET '/users/{user_id}'` where the `user_id` is as returned from 1 above
3. Update user: `PATCH '/users/{user_id}'` with the same `user_id` and a valid post body of the form: 
`{
    "first_name": "Jrue",
    "last_name": "Holiday",
    "phone": "5432198760",
    "company": "The Bucks"
}`. Try this endpoint with badly structured or invalid JSON data too.

### Issue Reference
- #38 
- #99
- #37

### Pending tasks
- Input field validation