### PR TITLE
member update settings functionality added

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func Router(Server *socketio.Server) *mux.Router {
 	r.HandleFunc("/organizations/{id}/url", auth.IsAuthenticated(organizations.UpdateUrl)).Methods("PATCH")
 	r.HandleFunc("/organizations/{id}/name", auth.IsAuthenticated(organizations.UpdateName)).Methods("PATCH")
 	r.HandleFunc("/organizations/{id}/logo", auth.IsAuthenticated(organizations.UpdateLogo)).Methods("PATCH")
-	
+
 	r.HandleFunc("/organizations/{id}/members", auth.IsAuthenticated(organizations.CreateMember)).Methods("POST")
 	r.HandleFunc("/organizations/{id}/members", auth.IsAuthenticated(organizations.GetMembers)).Methods("GET")
 	r.HandleFunc("/organizations/{id}/members/{mem_id}", auth.IsAuthenticated(organizations.GetMember)).Methods("GET")
@@ -57,7 +57,7 @@ func Router(Server *socketio.Server) *mux.Router {
 	r.HandleFunc("/organizations/{id}/members/{mem_id}/photo", auth.IsAuthenticated(organizations.UpdateProfilePicture)).Methods("PATCH")
 	r.HandleFunc("/organizations/{id}/members/{mem_id}/profile", auth.IsAuthenticated(organizations.UpdateProfile)).Methods("PATCH")
 	r.HandleFunc("/organizations/{id}/members/{mem_id}/presence", auth.IsAuthenticated(organizations.TogglePresence)).Methods("POST")
-
+	r.HandleFunc("/organizations/{id}/members/{mem_id}/settings", auth.IsAuthenticated(organizations.UpdateMemberSettings)).Methods("PATCH")
 	// Data
 	r.HandleFunc("/data/write", data.WriteData)
 	r.HandleFunc("/data/read/{plugin_id}/{coll_name}/{org_id}", data.ReadData).Methods("GET")

--- a/organizations/models.go
+++ b/organizations/models.go
@@ -60,23 +60,24 @@ func GetOrgPluginCollectionName(orgName string) string {
 // }
 
 type Member struct {
-	ID          string             `json:"_id" bson:"_id"`
-	OrgId       primitive.ObjectID `json:"org_id" bson:"org_id"`
-	Files       []string           `json:"files" bson:"files"`
-	ImageURL    string             `json:"image_url" bson:"image_url"`
-	Name        string             `json:"name" bson:"name"`
-	Email       string             `json:"email" bson:"email"`
-	DisplayName string             `json:"display_name" bson:"display_name"`
-	Bio         string             `json:"bio" bson:"bio"`
-	Status      string             `json:"status" bson:"status"`
-	Presence    string             `json:"presence" bson:"presence"`
-	Pronouns    string             `json:"pronouns" bson:"pronouns"`
-	Phone       string             `json:"phone" bson:"phone"`
-	TimeZone    string             `json:"time_zone" bson:"time_zone"`
-	Role        string             `json:"role" bson:"role"`
-	JoinedAt    time.Time          `json:"joined_at" bson:"joined_at"`
-	Deleted     bool               `json:"deleted" bson:"deleted"`
-	DeletedAt   time.Time          `json:"deleted_at" bson:"deleted_at"`
+	ID          primitive.ObjectID     `json:"_id" bson:"_id"`
+	OrgId       string                 `json:"org_id" bson:"org_id"`
+	Files       []string               `json:"files" bson:"files"`
+	ImageURL    string                 `json:"image_url" bson:"image_url"`
+	Name        string                 `json:"name" bson:"name"`
+	Email       string                 `json:"email" bson:"email"`
+	DisplayName string                 `json:"display_name" bson:"display_name"`
+	Bio         string                 `json:"bio" bson:"bio"`
+	Status      string                 `json:"status" bson:"status"`
+	Presence    string                 `json:"presence" bson:"presence"`
+	Pronouns    string                 `json:"pronouns" bson:"pronouns"`
+	Phone       string                 `json:"phone" bson:"phone"`
+	TimeZone    string                 `json:"time_zone" bson:"time_zone"`
+	Role        string                 `json:"role" bson:"role"`
+	JoinedAt    time.Time              `json:"joined_at" bson:"joined_at"`
+	Settings    map[string]interface{} `json:"settings" bson:"settings"`
+	Deleted     bool                   `json:"deleted" bson:"deleted"`
+	DeletedAt   time.Time              `json:"deleted_at" bson:"deleted_at"`
 	// Socials     Social    `json:"socials" bson:"socials"`
 }
 

--- a/organizations/organizations.go
+++ b/organizations/organizations.go
@@ -124,7 +124,7 @@ func Create(w http.ResponseWriter, r *http.Request) {
 
 	newMember := Member{
 		Email:    user.Email,
-		OrgId:    hexOrgid,
+		OrgId:    hexOrgid.Hex(),
 		Role:     "owner",
 		Presence: "true",
 	}


### PR DESCRIPTION
This commit adds the endpoint 
  **PATCH**  `/organizations/{id}/members/{member_id}/settings`
which takes a json payload indicating the settings value to update e.g 
```json
{ 
    "check_spelling": true,
}
```
The settings updated will be added to the existing settings data and the updated member object is returned.