### PR TITLE
fix(contact): update contact us function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ todolist/
 views/
 .vscode
 .idea
-zc_contact
+files
 contact_test.go
 validator_test.go

--- a/contact/contact.go
+++ b/contact/contact.go
@@ -101,10 +101,10 @@ func GenerateContactData(email, subject, content string, paths []string) Contact
 // SaveFileToFS saves each form file uploaded to the filesystem
 func SaveFileToFS(folderName string, fileHeader *multipart.FileHeader) error {
 	file, err := fileHeader.Open()
-	defer file.Close()
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
 	_, err = os.Stat(folderName)
 	if err != nil {
@@ -115,10 +115,10 @@ func SaveFileToFS(folderName string, fileHeader *multipart.FileHeader) error {
 	}
 
 	destinationFile, err := os.Create(folderName + "/" + fileHeader.Filename)
-	defer destinationFile.Close()
 	if err != nil {
 		return err
 	}
+	defer destinationFile.Close()
 
 	_, err = io.Copy(destinationFile, file)
 	if err != nil {

--- a/contact/models.go
+++ b/contact/models.go
@@ -4,13 +4,14 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"zuri.chat/zccore/service"
 )
 
 type ContactFormData struct {
-	ID          primitive.ObjectID `json:"id,omitempty"`
-	Subject     string             `json:"subject"`
-	Content     string             `json:"content"`
-	Attachments []string           `json:"attachments"`
-	Email       string             `json:"email"`
-	CreatedAt   time.Time          `json:"created_at"`
+	ID        primitive.ObjectID             `json:"id,omitempty"`
+	Subject   string                         `json:"subject"`
+	Content   string                         `json:"content"`
+	Files     []service.MultipleTempResponse `json:"attachments"`
+	Email     string                         `json:"email"`
+	CreatedAt time.Time                      `json:"created_at"`
 }

--- a/contact/validator.go
+++ b/contact/validator.go
@@ -10,14 +10,15 @@ import (
 
 const (
 	MAX_FILE_COUNT  = 5
-	MAX_FILE_SIZE   = int64(1024 * 1024) // 2 MB
+	MAX_FILE_SIZE   = int64(2 * 1024 * 1024) // 2 MB
 	MAX_EMAIL_COUNT = 254
 )
 
 var (
 	EmailRX           = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
 	AcceptedFileTypes = []string{"jpeg", "jpg", "png", "webp", "bmp", "pdf", "docx", "doc"}
-	folderName        = "zc_contact"
+	folderName        = "contact"
+	exts              = []string{"png", "jpeg", "jpg", "bmp", "doc", "pdf", "docx"}
 )
 
 type Validator struct {
@@ -66,49 +67,34 @@ func EmailMatches(value string, rx *regexp.Regexp) bool {
 
 // Empty returns true if a specific, trimmed value is empty
 func Empty(value string) bool {
-	if strings.TrimSpace(value) == "" {
-		return false
-	}
-	return true
+	return strings.TrimSpace(value) != ""
 }
 
 // CharacterCount returns true if the character count of a given value is less
 // than a given integer(count)
 func CharacterCount(value string, count int) bool {
-	if utf8.RuneCountInString(value) < count {
-		return true
-	}
-	return false
+	return utf8.RuneCountInString(value) < count
 }
 
 // AttachmentLength returns true if length of array is less than MAX_FILE_COUNT of 5
 func AttachmentLength(list []*multipart.FileHeader) bool {
-	if len(list) > MAX_FILE_COUNT {
-		return false
-	}
-	return true
+	return len(list) <= MAX_FILE_COUNT
 }
 
 // EmailLength returns true if length of email is less than MAX_EMAIL_COUNT of 254
 func EmailLength(email string) bool {
-	if len(email) < MAX_EMAIL_COUNT+1 {
-		return true
-	}
-	return false
+	return len(email) < MAX_EMAIL_COUNT+1
 }
 
 // FileSize returns true if the file size of a given file is less than
 // MAX_FILE_SIZE of 2MB
 func FileSize(file *multipart.FileHeader) bool {
-	if file.Size > MAX_FILE_SIZE {
-		return false
-	}
-	return true
+	return file.Size < MAX_FILE_SIZE
 }
 
 // AcceptFileSize returns true if the extension of the uploaded files matches the
 // allowed file extensions
-func AcceptFileType(file *multipart.FileHeader, exts ...string) bool {
+func AcceptFileType(file *multipart.FileHeader, exts []string) bool {
 	filename := file.Filename
 	fileExtension := filepath.Ext(filename)
 	for _, ext := range exts {
@@ -142,7 +128,7 @@ func ValidateAttachedFiles(validator Validator, attachments []*multipart.FileHea
 	if len(attachments) > 0 {
 		validator.Check(AttachmentLength(attachments), "attachments", "file count exceeded")
 		for _, attachment := range attachments {
-			validator.Check(AcceptFileType(attachment, "png", "jpeg", "jpg", "bmp"), "attachments", "invalid file type")
+			validator.Check(AcceptFileType(attachment, exts), "attachments", "invalid file type")
 			validator.Check(FileSize(attachment), "attachments", "maximum file size exceeded")
 		}
 

--- a/service/uploadfile.go
+++ b/service/uploadfile.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"os"
+
 	// uuser "os/user"
 	"path/filepath"
 	"strings"
@@ -124,8 +125,6 @@ func MultipleFileUpload(folderName string, r *http.Request) ([]MultipleTempRespo
 		filename, errr := pickFileName(filenamePrefix, fileExtension)
 		// wfilename := filepath.Join(cwd,filename)
 
-
-
 		if errr != nil {
 			return nil, errr
 		}
@@ -153,7 +152,6 @@ func MultipleFileUpload(folderName string, r *http.Request) ([]MultipleTempRespo
 			return nil, err
 		}
 		filename_e := strings.Join(strings.Split(filename, "\\"), "/")
-
 
 		var urlPrefix string = "https://api.zuri.chat/"
 		if r.Host == "127.0.0.1:8080" {
@@ -201,7 +199,7 @@ func UploadOneFile(w http.ResponseWriter, r *http.Request) {
 		utils.GetError(fmt.Errorf("Acess Denied, Plugin does not exist"), http.StatusForbidden, w)
 		return
 	}
-	url, err:= SingleFileUpload(plugin_id, r)
+	url, err := SingleFileUpload(plugin_id, r)
 	if err != nil {
 		utils.GetError(err, http.StatusBadRequest, w)
 		return
@@ -221,7 +219,7 @@ func UploadMultipleFiles(w http.ResponseWriter, r *http.Request) {
 		utils.GetError(fmt.Errorf("Acess Denied, Plugin does not exist"), http.StatusForbidden, w)
 		return
 	}
-	list, err:= MultipleFileUpload(plugin_id, r)
+	list, err := MultipleFileUpload(plugin_id, r)
 	if err != nil {
 		utils.GetError(err, http.StatusBadRequest, w)
 		return
@@ -251,13 +249,13 @@ func DeleteFile(w http.ResponseWriter, r *http.Request) {
 		utils.GetError(fmt.Errorf("Delete Not Allowed for plugin of Id: "+plugin_id), http.StatusForbidden, w)
 		return
 	}
-	var urldom string ="api.zuri.chat"
+	var urldom string = "api.zuri.chat"
 	if r.Host == "127.0.0.1:8080" {
 		urldom = "127.0.0.1:8080"
 	}
 	filePath := "." + strings.Split(delFile.FileUrl, urldom)[1]
 	cwd, _ := os.Getwd()
-	filePath = filepath.Join(cwd,filePath)
+	filePath = filepath.Join(cwd, filePath)
 	er := DeleteFileFromServer(filePath)
 	if er != nil {
 		utils.GetError(er, http.StatusBadRequest, w)
@@ -320,10 +318,10 @@ func saveFile(folderName string, file multipart.File, handle *multipart.FileHead
 
 	filename_e := strings.Join(strings.Split(filename, "\\"), "/")
 	var urlPrefix string = "https://api.zuri.chat/"
-		if r.Host == "127.0.0.1:8080" {
-			urlPrefix = "127.0.0.1:8080/"
-		}
-		fileUrl := urlPrefix + filename_e
+	if r.Host == "127.0.0.1:8080" {
+		urlPrefix = "127.0.0.1:8080/"
+	}
+	fileUrl := urlPrefix + filename_e
 	return fileUrl, nil
 }
 


### PR DESCRIPTION
### What does this PR do?   
 - change HTTP response status code to reflect bad request sent by user
 - modify the ContactFormData model to represent user input data and unified struct (service.MultipleTempResponse) for uploaded files
 - change the form field for uploaded files from `attachments` to `file`
 - saves contact form data to db and any uploaded files to the filesystem
### How should this be tested?
- As outlined in #316 
### Pending tasks
- None
### Workflow reference
- Name: Contact Us 
### Additional information
- subject: Word count limit set to 100
- content: Word count limit set to 500
- file: File types limited to .jpg, .jpeg, .png, .bmp, .pdf, .docx. Total files uploaded cannot exceed 5, and each file size is pegged to 2 MB
