### PR TITLE
Allow plugin perform raw mongodb queries to update data

### DIFF
--- a/contact/contact.go
+++ b/contact/contact.go
@@ -85,7 +85,7 @@ func ContactUs(w http.ResponseWriter, r *http.Request) {
 		utils.GetError(err, http.StatusInternalServerError, w)
 		return
 	}
-	utils.GetSuccess("contact information sent successfully", mongoRes, w)
+	utils.GetSuccess("contact information sent successfully", utils.M{"id": mongoRes.InsertedID}, w)
 
 }
 

--- a/data/delete_data.go
+++ b/data/delete_data.go
@@ -34,11 +34,11 @@ func DeleteData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//if !recordExists(_OrganizationCollectionName, reqData.OrganizationID) {
-	//msg := "organization with this id does not exist"
-	//utils.GetError(errors.New(msg), http.StatusNotFound, w)
-	//return
-	//}
+	if !recordExists(_OrganizationCollectionName, reqData.OrganizationID) {
+	msg := "organization with this id does not exist"
+	utils.GetError(errors.New(msg), http.StatusNotFound, w)
+	return
+	}
 
 	// if plugin is writing to this collection the first time, we create a record linking this collection to the plugin.
 	if !pluginHasCollection(reqData.PluginID, reqData.OrganizationID, reqData.CollectionName) {

--- a/data/write_data.go
+++ b/data/write_data.go
@@ -35,11 +35,11 @@ func WriteData(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	//if !recordExists(_OrganizationCollectionName, reqData.OrganizationID) {
-	//msg := "organization with this id does not exist"
-	//utils.GetError(errors.New(msg), http.StatusNotFound, w)
-	//return
-	//}
+	if !recordExists(_OrganizationCollectionName, reqData.OrganizationID) {
+	msg := "organization with this id does not exist"
+	utils.GetError(errors.New(msg), http.StatusNotFound, w)
+	return
+	}
 
 	// if plugin is writing to this collection the first time, we create a record linking this collection to the plugin.
 	if !pluginHasCollection(reqData.PluginID, reqData.OrganizationID, reqData.CollectionName) {

--- a/marketplace/plugins.go
+++ b/marketplace/plugins.go
@@ -67,11 +67,11 @@ func RemovePlugin(w http.ResponseWriter, r *http.Request) {
 
 	update := M{"deleted": true, "deleted_at": time.Now().String()}
 
-	updateRes, err := utils.UpdateOneMongoDbDoc(plugin.PluginCollectionName, pluginID, update)
+	_, err = utils.UpdateOneMongoDbDoc(plugin.PluginCollectionName, pluginID, update)
 	if err != nil {
 		utils.GetError(errors.New("plugin removal failed"), http.StatusBadRequest, w)
 		return
 	}
 
-	utils.GetSuccess("plugin successfully removed", updateRes, w)
+	utils.GetSuccess("plugin removed", nil, w)
 }

--- a/organizations/organizations.go
+++ b/organizations/organizations.go
@@ -106,7 +106,6 @@ func (oh *OrganizationHandler) Create(w http.ResponseWriter, r *http.Request) {
 	creator, _ := auth.FetchUserByEmail(bson.M{"email": userEmail})
 	var ccreatorid string = creator.ID
 
-
 	userDoc, _ := utils.GetMongoDbDoc(UserCollectionName, bson.M{"email": newOrg.CreatorEmail})
 	if userDoc == nil {
 		fmt.Printf("user with email %s does not exist!", newOrg.CreatorEmail)
@@ -166,13 +165,13 @@ func (oh *OrganizationHandler) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bot := Member{
-		ID:       primitive.NewObjectID(),
-		OrgId:    iiid,
+		ID:        primitive.NewObjectID(),
+		OrgId:     iiid,
 		FirstName: "TwitterBot",
-		Role:     Bot,
-		Presence: "true", 
-		JoinedAt: time.Now(),
-		Deleted:  false,
+		Role:      Bot,
+		Presence:  "true",
+		JoinedAt:  time.Now(),
+		Deleted:   false,
 	}
 
 	// add bot as member of organization
@@ -183,7 +182,7 @@ func (oh *OrganizationHandler) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	utils.GetSuccess("organization created", save, w)
+	utils.GetSuccess("organization created", utils.M{"organization_id": save.InsertedID}, w)
 }
 
 // Get all organization records
@@ -533,7 +532,7 @@ func IsProVersion(OrgId string) (bool, error) {
 func (oh *OrganizationHandler) SaveBillingSettings(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	orgId := mux.Vars(r)["id"]
-	
+
 	var billingSetting BillingSetting
 	err := utils.ParseJsonFromRequest(r, &billingSetting)
 	if err != nil {
@@ -548,12 +547,12 @@ func (oh *OrganizationHandler) SaveBillingSettings(w http.ResponseWriter, r *htt
 		return
 	}
 
-	billing := Billing {
+	billing := Billing{
 		billingSetting,
 	}
 
 	loggedInUser := r.Context().Value("user").(*auth.AuthUser)
-	if  _, err := FetchMember(bson.M{"org_id": orgId, "email": loggedInUser.Email}); err != nil {
+	if _, err := FetchMember(bson.M{"org_id": orgId, "email": loggedInUser.Email}); err != nil {
 		utils.GetError(errors.New("access denied"), http.StatusNotFound, w)
 		return
 	}
@@ -566,7 +565,7 @@ func (oh *OrganizationHandler) SaveBillingSettings(w http.ResponseWriter, r *htt
 		utils.GetError(err, http.StatusInternalServerError, w)
 		return
 	}
-	
+
 	if update.ModifiedCount == 0 {
 		utils.GetError(errors.New("operation failed"), http.StatusUnprocessableEntity, w)
 		return

--- a/plugin/Readme.md
+++ b/plugin/Readme.md
@@ -18,11 +18,11 @@ To create a plugin, go to the following endpoint with the following data
 "version": "v1",
 "tags": ["some", "nice", "tags"],
 "category": "some category",
-"pictures": ["some.jpeng", "to.jpeng", "be.jpeng", "displayed.peng"]
+"images": ["some.jpeng", "pictures.peng", "to.jpeng", "be.jpeng", "displayed.peng"]
 }
 
 ```
-Every field here is required, else validation error will occur.
+The first 7 fields here is required, else validation error will occur.
 After a success message is received, the plugin is the approved to be listed on marketplace. It takes 10 seconds before the plugin can be listed in the marketplace.
 
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -50,39 +50,16 @@ func approvePlugin(id string) {
 }
 
 func Update(w http.ResponseWriter, r *http.Request) {
-	// pp := PluginPatch{}
-	var pp PluginPatch
+	pp := PluginPatch{}
 	id := mux.Vars(r)["id"]
 	if err := utils.ParseJsonFromRequest(r, &pp); err != nil {
 		utils.GetError(errors.WithMessage(err, "error processing request"), 422, w)
 		return
 	}
-	// if err := updatePlugin(r.Context(), id, pp); err != nil {
-	// 	utils.GetError(errors.WithMessage(err, "cannot update, bad request"), 400, w)
-	// 	return
-	// }
-	pluginMap, err := utils.StructToMap(pp)
-	if err != nil {
-		utils.GetError(err, http.StatusInternalServerError, w)
-	}
-
-	updateFields := make(map[string]interface{})
-	for key, value := range pluginMap {
-		if value != "" {
-			updateFields[key] = value
-		}
-	}
-	if len(updateFields) == 0 {
-		utils.GetError(errors.New("empty/invalid user input data"), http.StatusBadRequest, w)
+	if err := updatePlugin(r.Context(), id, pp); err != nil {
+		utils.GetError(errors.WithMessage(err, "cannot update, bad request"), 400, w)
 		return
-	} else {
-		_, err := utils.UpdateOneMongoDbDoc(PluginCollectionName, id, updateFields)
-		if err != nil {
-			utils.GetError(errors.New("Plugin update failed"), http.StatusInternalServerError, w)
-			return
-		}
 	}
-
 	utils.GetSuccess("updated plugin successfully", nil, w)
 }
 

--- a/report/report.go
+++ b/report/report.go
@@ -91,7 +91,7 @@ func AddReport(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	utils.GetSuccess("report created", save, w)
+	utils.GetSuccess("report created", utils.M{"report_id": save.InsertedID}, w)
 }
 
 // Get a report

--- a/user/user.go
+++ b/user/user.go
@@ -197,12 +197,12 @@ func (uh *UserHandler) UpdateUser(response http.ResponseWriter, request *http.Re
 		utils.GetError(errors.New("empty/invalid user input data"), http.StatusBadRequest, response)
 		return
 	}
-	updateRes, err := utils.UpdateOneMongoDbDoc(collectionName, userID, updateFields)
+	_, err = utils.UpdateOneMongoDbDoc(collectionName, userID, updateFields)
 	if err != nil {
 			utils.GetError(errors.New("user update failed"), http.StatusInternalServerError, response)
 			return
 		}
-	utils.GetSuccess("user successfully updated", updateRes, response)
+	utils.GetSuccess("user successfully updated", nil, response)
 }
 
 // get all users


### PR DESCRIPTION
This commit adds a raw_query field to allow plugins send valid mongodb queries and modifiers to update their data
Also makes adjustments to generic responses when creating a resource e.g `InsertedID` instead of `user_id` and removes some unnecessary responses 