### PR TITLE
feat(auth-centrifugo): authenticate client connections

### DIFF
--- a/realtime/realtime.go
+++ b/realtime/realtime.go
@@ -39,11 +39,14 @@ type CentrifugoRefreshResult struct {
 	ExpireAt string `json:"expire_at" bson:"expire_at"`
 }
 
+type CentrifugoClientData map[string]string
+
 type CentrifugoConnectRequest struct {
-	Client    string `json:"client" bson:"client"`
-	Transport string `json:"transport" bson:"transport"`
-	Protocol  string `json:"protocol" bson:"protocol"`
-	Encoding  string `json:"encoding" bson:"encoding"`
+	Client    string               `json:"client" bson:"client"`
+	Transport string               `json:"transport" bson:"transport"`
+	Protocol  string               `json:"protocol" bson:"protocol"`
+	Encoding  string               `json:"encoding" bson:"encoding"`
+	Data      CentrifugoClientData `json:"data" bson:"data"`
 }
 
 func Auth(w http.ResponseWriter, r *http.Request) {
@@ -60,6 +63,10 @@ func Auth(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	// 2. Authenticate client connect request
+	token := creq.Data["bearer"]
+	fmt.Println(token)
 
 	u, _ := uuid.NewV4()
 	data := CentrifugoConnectResponse{}

--- a/realtime/test_rtc.html
+++ b/realtime/test_rtc.html
@@ -22,7 +22,7 @@
                 document.title = ctx.data.value;
             });
 
-            let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb29raWUiOiJNVFl6TXpFNU1ESXhNM3hIZDNkQlIwUlplRTVVWnpSTlZGRXhXVlJOTkZwRVVtcE9hbWMxV2tSc2FGcHFWWHBPZHowOWZKOHJXVDZjVXBvbERNUHBmeWZCUHZxWm11aTFzUi14bXBFOFF6Wl9FOU9lIiwiZW1haWwiOiJtaW50QGVtYWlsLmNvbSIsImlkIjoiNjE1ODgxNDVhMzhkNGM2ODlkOWFmNTM3Iiwib3B0aW9ucyI6eyJQYXRoIjoiLyIsIkRvbWFpbiI6IiIsIk1heEFnZSI6Nzk0MDM5MDE4OCwiU2VjdXJlIjpmYWxzZSwiSHR0cE9ubHkiOmZhbHNlLCJTYW1lU2l0ZSI6MH0sInNlc3Npb25fbmFtZSI6ImY2ODIyYWY5NGUyOWJhMTEyYmUzMTBkM2FmNDVkNWM3In0.7Rx8ALwQtHVslzaBK4fvqc2T-TP-QtqhMJ0XI2AK3eY"
+            let token = "token"
             
             centrifuge.setConnectData({"bearer": token});
             centrifuge.connect();

--- a/realtime/test_rtc.html
+++ b/realtime/test_rtc.html
@@ -22,6 +22,7 @@
                 document.title = ctx.data.value;
             });
 
+            centrifuge.setConnectData({"bearer": "token"});
             centrifuge.connect();
         </script>
 

--- a/realtime/test_rtc.html
+++ b/realtime/test_rtc.html
@@ -22,7 +22,9 @@
                 document.title = ctx.data.value;
             });
 
-            centrifuge.setConnectData({"bearer": "token"});
+            let token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJjb29raWUiOiJNVFl6TXpFNU1ESXhNM3hIZDNkQlIwUlplRTVVWnpSTlZGRXhXVlJOTkZwRVVtcE9hbWMxV2tSc2FGcHFWWHBPZHowOWZKOHJXVDZjVXBvbERNUHBmeWZCUHZxWm11aTFzUi14bXBFOFF6Wl9FOU9lIiwiZW1haWwiOiJtaW50QGVtYWlsLmNvbSIsImlkIjoiNjE1ODgxNDVhMzhkNGM2ODlkOWFmNTM3Iiwib3B0aW9ucyI6eyJQYXRoIjoiLyIsIkRvbWFpbiI6IiIsIk1heEFnZSI6Nzk0MDM5MDE4OCwiU2VjdXJlIjpmYWxzZSwiSHR0cE9ubHkiOmZhbHNlLCJTYW1lU2l0ZSI6MH0sInNlc3Npb25fbmFtZSI6ImY2ODIyYWY5NGUyOWJhMTEyYmUzMTBkM2FmNDVkNWM3In0.7Rx8ALwQtHVslzaBK4fvqc2T-TP-QtqhMJ0XI2AK3eY"
+            
+            centrifuge.setConnectData({"bearer": token});
             centrifuge.connect();
         </script>
 


### PR DESCRIPTION
### What does this PR do?
- Authenticate all client connect request to the RTC endpoint
### Tasks completed
- Authenticate connect: `POST '/realtime/auth'`
### Pending tasks
- Refresh connection
### How should this be tested?
- Send a connect request to the RTC websocket address with `centrifuge.setConnectData({"bearer": <TOKEN>})` where the `<TOKEN>` is the bearer token assigned every authenticated zurichat user at log in.