### PR TITLE
Change invite link base url to staging.zuri.chat

### DIFF
--- a/organizations/organizations.go
+++ b/organizations/organizations.go
@@ -449,7 +449,7 @@ func (oh *OrganizationHandler) SendInvite(w http.ResponseWriter, r *http.Request
 		inviteIDs = append(inviteIDs, save.InsertedID)
 
 		// Parse data for customising email template
-		inviteLink := fmt.Sprintf("https://zuri.chat/invites/%s", uuid)
+		inviteLink := fmt.Sprintf("https://staging.zuri.chat/invites/%s", uuid)
 		orgName := fmt.Sprintf("%v", org["name"])
 
 		msger := oh.mailService.NewMail(


### PR DESCRIPTION
## Issue

- The invitelink in the email invite template still points to `https://www.zuri.chat/invites ` which is not working

## Fix
- Update the invite link according to the current domain: **staging.zuri.chat**
- The invite links will now follow this URL: `staging.zuri.chat/invites/{inviteID}`

@Aminujb @kinglighthill 