### PR TITLE
fix(BAC-64): delete workspace fix

### DIFF
--- a/organizations/organizations.go
+++ b/organizations/organizations.go
@@ -220,6 +220,18 @@ func (oh *OrganizationHandler) DeleteOrganization(w http.ResponseWriter, r *http
 		utils.GetError(errors.New("operation failed"), http.StatusInternalServerError, w)
 		return
 	}
+	filter := bson.M{"org_id": orgID}
+	response1, err2 := utils.DeleteManyMongoDBDoc(MemberCollectionName,filter)
+
+	if err2 != nil {
+		utils.GetError(err, http.StatusInternalServerError, w)
+		return
+	}
+
+	if response1.DeletedCount == 0 {
+		utils.GetError(errors.New("operation failed"), http.StatusInternalServerError, w)
+		return
+	}
 
 	utils.GetSuccess("organization deleted successfully", nil, w)
 }

--- a/user/user.go
+++ b/user/user.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"zuri.chat/zccore/service"
 	"zuri.chat/zccore/utils"
@@ -298,13 +299,15 @@ func (uh *UserHandler) GetUserOrganizations(response http.ResponseWriter, reques
 			}
 			orgDetailsChannel <- resp
 		}()
-
+			
 		MembersLengthData, orgDetailsData, basicimagesdata := <-MembersLengthChannel, <-orgDetailsChannel, <-ImageUrlsChannel
 		basic["no_of_members"], basic["isOwner"], basic["member_id"] = MembersLengthData.Interger, value["role"] == "owner", value["_id"]
 
 		if MembersLengthData.Err != nil || orgDetailsData.Err != nil || basicimagesdata.Err != nil {
-			utils.GetError(fmt.Errorf("query Failed, try again later"), http.StatusUnprocessableEntity, response)
-			return
+			if orgDetailsData.Err != mongo.ErrNoDocuments {
+				utils.GetError(fmt.Errorf("query Failed, try again later"), http.StatusUnprocessableEntity, response)
+				return
+			}
 		}
 
 		orgDetails := orgDetailsData.Bson


### PR DESCRIPTION
## [Linear Ticket](https://linear.app/team-brainbox/issue/BAC-64/zuri-chat)

## Details: 
When a workspace owner deletes their workspace/organization, it messes up the GET users organizations' endpoint and returns an error.

### Intended behaviour: 
Frontend should be able to get a list of all the organizations a user belongs to. It should not throw an error if one of those workspaces may have been deleted by the owner.

### Proposed fixes
- When an organization is deleted, all members of the organization should be deleted in the "members" collection, and the ID of the organization should be removed from a list of organizations a user belongs to.
- Modify the error handling so that a "No document" error from mongo does not stop the rest of the data from being returned.

