### PR TITLE
Fix/multiple file upload wrong response issue

### DIFF
--- a/example.env
+++ b/example.env
@@ -15,3 +15,4 @@ CENTRIFUGO_ENDPOINT = https://realtime.zuri.chat/api
 # Agora APP ID and APP CERTIFICATE
 APP_ID=f910a1fb4cfe4c5996c979c54e570ba7
 APP_CERTIFICATE=04c4146b729d4bddaf9ce4ae107c9ff0
+SERVER_NAME=https://staging.api.zuri.chat/

--- a/plugin/models.go
+++ b/plugin/models.go
@@ -62,7 +62,7 @@ func FindPluginByID(ctx context.Context, id string) (*Plugin, error) {
 		return nil, err
 	}
 
-	res, err := utils.GetMongoDBDoc(PluginCollectionName, bson.M{"_id": objID})
+	res, err := utils.GetMongoDBDoc(PluginCollectionName, bson.M{"_id": objID, "deleted": false})
 
 	if err != nil {
 		return nil, err

--- a/plugin/models.go
+++ b/plugin/models.go
@@ -62,8 +62,7 @@ func FindPluginByID(ctx context.Context, id string) (*Plugin, error) {
 		return nil, err
 	}
 
-
-	res, err := utils.GetMongoDBDoc(PluginCollectionName, bson.M{"_id": objID, "deleted": false})
+	res, err := utils.GetMongoDBDoc(PluginCollectionName, bson.M{"_id": objID})
 
 	if err != nil {
 		return nil, err
@@ -92,9 +91,7 @@ func FindPluginByID(ctx context.Context, id string) (*Plugin, error) {
 func FindPlugins(ctx context.Context, filter bson.M, opts ...*options.FindOptions) ([]*Plugin, error) {
 	ps := []*Plugin{}
 
-
 	cursor, err := utils.GetMongoDBDocs(PluginCollectionName, filter, opts...)
-
 
 	if err != nil {
 		return nil, err
@@ -157,7 +154,7 @@ func FindPluginByTemplateURL(ctx context.Context, url string) (*Plugin, error) {
 
 	if err != nil {
 		return nil, err
-	}	
+	}
 
 	bsonBytes, err := bson.Marshal(res)
 

--- a/service/uploadfile.go
+++ b/service/uploadfile.go
@@ -176,7 +176,7 @@ func MultipleFileUpload(folderName string, r *http.Request) ([]MultipleTempRespo
 
 		filenameE := strings.Join(strings.Split(filename, "\\"), "/")
 
-		var urlPrefix = "https://api.zuri.chat/"
+		var urlPrefix = os.Getenv("SERVER_NAME")
 		if r.Host == localDH || r.Host == localDHL {
 			urlPrefix = hostPath
 		}

--- a/service/uploadfile.go
+++ b/service/uploadfile.go
@@ -133,9 +133,9 @@ func MultipleFileUpload(folderName string, r *http.Request) ([]MultipleTempRespo
 			return nil, fmt.Errorf("File type not allowed")
 		}
 
-		_, errr := file.Seek(0, io.SeekStart)
-		if errr != nil {
-			return nil, errr
+		_, err = file.Seek(0, io.SeekStart)
+		if err != nil {
+			return nil, err
 		}
 
 		if spl := strings.ReplaceAll(folderName, " ", ""); spl != "" {
@@ -147,24 +147,24 @@ func MultipleFileUpload(folderName string, r *http.Request) ([]MultipleTempRespo
 		fileExtension := filepath.Ext(fileHeader.Filename)
 		exeDir, newF := "files/"+folderName, ""
 		filenamePrefix := filepath.Join(exeDir, newF, buildFileName())
-		filename, errr := pickFileName(filenamePrefix, fileExtension)
+		filename, err := pickFileName(filenamePrefix, fileExtension)
 
-		if errr != nil {
-			return nil, errr
+		if err != nil {
+			return nil, err
 		}
 
-		_, err2 := os.Stat(exeDir)
-		if err2 != nil {
+		_, err = os.Stat(exeDir)
+		if err != nil {
 			err0 := os.MkdirAll(exeDir, permissionNumber)
 			if err0 != nil {
 				return nil, err0
 			}
 		}
 
-		destinationFile, erri := os.Create(filename)
+		destinationFile, err := os.Create(filename)
 
 		if err != nil {
-			return nil, erri
+			return nil, err
 		}
 
 		defer destinationFile.Close()

--- a/service/uploadfile.go
+++ b/service/uploadfile.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"image"
 	"image/gif"
@@ -41,7 +42,6 @@ const (
 )
 
 var (
-	res              []MultipleTempResponse
 	permissionNumber fs.FileMode = 0777
 	mg32             int64       = 32
 	mg20             int64       = 20
@@ -107,7 +107,12 @@ func MultipleFileUpload(folderName string, r *http.Request) ([]MultipleTempRespo
 		return nil, err
 	}
 
+	res := []MultipleTempResponse{}
 	files := r.MultipartForm.File["file"]
+	if files == nil {
+		return nil, errors.New("empty file upload")
+	}
+
 	for _, fileHeader := range files {
 		file, err := fileHeader.Open()
 		if err != nil {


### PR DESCRIPTION
### Issue description
The multiple file upload endpoint returns all previously uploaded files as a part of the response for the current upload.

### Fix
The issue was a package level variable that was been used every time a user uploads a file, on subsequent uploads, the same variable contains the state of the previous uploads, the fix is to make the variable local.
I also fixed the successful empty upload bug, an invalid filter query (checking for a field that does not exist in the user struct), make server name configurable and some minor refactoring of the err variable.